### PR TITLE
add ibus-setup, ibus-daemon information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ne-trad-ttf
 nepali traditional layouts mostly compatible with preeti, kantipur like ttf fonts. detailed description [here](http://nepalitankan.blogspot.com/2013/10/nepali-traditional.html)
 
 ## installation instructions for Windows 
-- download ne-ttf.zip from windows/bin directory 
+- download `ne-ttf.zip` from windows/bin directory 
 - extract and run setup.exe
 - Go to control panel->Regional settings->Keyboards and languages
 - new keyboard layout should be available under Nepali language named Nepali Traditional TTF
@@ -16,7 +16,21 @@ nepali traditional layouts mostly compatible with preeti, kantipur like ttf font
 - copy `ne-trad-ttf.mim` to `/usr/share/m17n` (installation dir of m17n-db as of 12.04)
 - copy `ne-trad-ttf.png` to `/usr/share/m17n/icons`
 - may need to restart ibus engine
-- new layout should be available under iBus preferences
+```bash
+# Restart Ibus
+$ sudo ibus restart
+```
+- If above command failed you might need to restart `ibus-daemon`
+```bash
+$ sudo ibus-daemon
+```
+- new layout should be available under iBus preferences, starting with Ubuntu13.10 `ibus preferences` is not available in Settings and we have to start it from terminal.
+
+### Open IBus Preferences from terminal
+
+```bash
+$ sudo ibus-setup
+```
 - [detailed instructions](http://nepalitankan.blogspot.com/2013/10/ne-trad-ttf-for-linux.html)
 
 ## layout image


### PR DESCRIPTION
Add information regarding **ibus-setup** and **ibus-daemon**
### ibus-setup

Starting with **Ubuntu13.10** IBus preferences no longer available in settings and has to be started manually from terminal using **ibus-setup**
### ibus-daemon

It needs to be available for **ibus-setup** to start.
